### PR TITLE
OPENEUROPA-1295: Make OE Content use RDF SKOS instead of RDF taxonomy

### DIFF
--- a/rdf_skos.services.yml
+++ b/rdf_skos.services.yml
@@ -10,3 +10,8 @@ services:
   rdf_skos.sparql.field_handler:
     class: Drupal\rdf_skos\RdfSkosFieldHandler
     parent: sparql.field_handler
+  rdf_skos.active_graph_subscriber:
+    class: Drupal\rdf_skos\EventSubscriber\SkosActiveGraphSubscriber
+    arguments: ['@entity_type.manager', '@rdf_skos.sparql.graph_handler']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/SkosActiveGraphSubscriber.php
+++ b/src/EventSubscriber/SkosActiveGraphSubscriber.php
@@ -56,17 +56,7 @@ class SkosActiveGraphSubscriber implements EventSubscriberInterface {
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    *   Thrown when the access is denied and redirects to user login page.
    */
-  public function graphForEntityConvert(ActiveGraphEvent $event): void {
-    $entity_type_id = $event->getEntityTypeId();
-    if (!in_array($entity_type_id, ['skos_concept_scheme', 'skos_concept'])) {
-      return;
-    }
-
-    // By default, we look in all graphs.
-    $graphs = $this->rdfGraphHandler->getEntityTypeGraphIds($entity_type_id);
-    $event->setGraphs($graphs);
-    $event->stopPropagation();
-  }
+  public function graphForEntityConvert(ActiveGraphEvent $event): void {}
 
   /**
    * {@inheritdoc}

--- a/src/EventSubscriber/SkosActiveGraphSubscriber.php
+++ b/src/EventSubscriber/SkosActiveGraphSubscriber.php
@@ -56,7 +56,17 @@ class SkosActiveGraphSubscriber implements EventSubscriberInterface {
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    *   Thrown when the access is denied and redirects to user login page.
    */
-  public function graphForEntityConvert(ActiveGraphEvent $event): void {}
+  public function graphForEntityConvert(ActiveGraphEvent $event): void {
+    $entity_type_id = $event->getEntityTypeId();
+    if (!in_array($entity_type_id, ['skos_concept_scheme', 'skos_concept'])) {
+      return;
+    }
+
+    // By default, we look in all graphs.
+    $graphs = $this->rdfGraphHandler->getEntityTypeGraphIds($entity_type_id);
+    $event->setGraphs($graphs);
+    $event->stopPropagation();
+  }
 
   /**
    * {@inheritdoc}

--- a/src/EventSubscriber/SkosActiveGraphSubscriber.php
+++ b/src/EventSubscriber/SkosActiveGraphSubscriber.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\rdf_entity\ActiveGraphEvent;
+use Drupal\rdf_entity\Event\RdfEntityEvents;
+use Drupal\rdf_entity\RdfGraphHandlerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Ensure the correct graph is used for reading the SKOS entities.
+ *
+ * We use this when the SKOS entities are param converted to ensure that for
+ * the SKOS entity types, only the correct graphs are used.
+ *
+ * @see \Drupal\rdf_entity\ParamConverter\RdfEntityConverter
+ */
+class SkosActiveGraphSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The RDF graph handler service.
+   *
+   * @var \Drupal\rdf_entity\RdfGraphHandlerInterface
+   */
+  protected $rdfGraphHandler;
+
+  /**
+   * Constructs a new event subscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\rdf_entity\RdfGraphHandlerInterface $rdf_graph_handler
+   *   The RDF graph handler service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, RdfGraphHandlerInterface $rdf_graph_handler) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->rdfGraphHandler = $rdf_graph_handler;
+  }
+
+  /**
+   * Set the appropriate graph as an active graph for the SKOS entities.
+   *
+   * @param \Drupal\rdf_entity\ActiveGraphEvent $event
+   *   The event object to process.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   *   Thrown when the access is denied and redirects to user login page.
+   */
+  public function graphForEntityConvert(ActiveGraphEvent $event): void {
+    $entity_type_id = $event->getEntityTypeId();
+    if (!in_array($entity_type_id, ['skos_concept_scheme', 'skos_concept'])) {
+      return;
+    }
+
+    // By default, we look in all graphs.
+    $graphs = $this->rdfGraphHandler->getEntityTypeGraphIds($entity_type_id);
+    $event->setGraphs($graphs);
+    $event->stopPropagation();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      RdfEntityEvents::GRAPH_ENTITY_CONVERT => ['graphForEntityConvert', 100],
+    ];
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/SkosConceptEntityReferenceLabelFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SkosConceptEntityReferenceLabelFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
+
+/**
+ * Plugin implementation of the 'skos_concept_entity_reference_label' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "skos_concept_entity_reference_label",
+ *   label = @Translation("SKOS Concept Label"),
+ *   description = @Translation("Display the label of the referenced concepts."),
+ *   field_types = {
+ *     "skos_concept_entity_reference"
+ *   }
+ * )
+ */
+class SkosConceptEntityReferenceLabelFormatter extends EntityReferenceLabelFormatter {}

--- a/src/Plugin/Field/FieldType/SkosConceptEntityReferenceItem.php
+++ b/src/Plugin/Field/FieldType/SkosConceptEntityReferenceItem.php
@@ -18,8 +18,8 @@ use Drupal\Core\Form\FormStateInterface;
  *   label = @Translation("SKOS Concept Reference"),
  *   description = @Translation("References SKOS Concepts."),
  *   category = @Translation("SKOS"),
- *   default_widget = "entity_reference_autocomplete",
- *   default_formatter = "entity_reference_label",
+ *   default_widget = "skos_concept_entity_reference_autocomplete",
+ *   default_formatter = "skos_concept_entity_reference_label",
  *   list_class = "\Drupal\Core\Field\EntityReferenceFieldItemList",
  * )
  */

--- a/src/Plugin/Field/FieldWidget/SkosConceptEntityReferenceAutocompleteWidget.php
+++ b/src/Plugin/Field/FieldWidget/SkosConceptEntityReferenceAutocompleteWidget.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\Plugin\Field\FieldWidget\EntityReferenceAutocompleteWidget;
+
+/**
+ * Plugin for the 'skos_concept_entity_reference_autocomplete' widget.
+ *
+ * @FieldWidget(
+ *   id = "skos_concept_entity_reference_autocomplete",
+ *   label = @Translation("SKOS Concept Autocomplete"),
+ *   description = @Translation("An autocomplete text field for SKOS Concepts."),
+ *   field_types = {
+ *     "skos_concept_entity_reference"
+ *   }
+ * )
+ */
+class SkosConceptEntityReferenceAutocompleteWidget extends EntityReferenceAutocompleteWidget {}

--- a/tests/Kernel/RdfSkosEntitiesKernelTest.php
+++ b/tests/Kernel/RdfSkosEntitiesKernelTest.php
@@ -4,6 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\rdf_skos\Kernel;
 
+use Drupal\rdf_skos\Entity\ConceptInterface;
+use Symfony\Component\HttpFoundation\Request;
+
 /**
  * Tests the RDF SKOS entities.
  */
@@ -110,6 +113,22 @@ class RdfSkosEntitiesKernelTest extends RdfSkosKernelTestBase {
     $ids = $entity_type_manager->getStorage('skos_concept')->getQuery()
       ->execute();
     $this->assertCount(7, $ids);
+  }
+
+  /**
+   * Tests that for SKOS entities we get the correct active graphs.
+   */
+  public function testActiveGraphs(): void {
+    $this->enableGraph('fruit');
+    $url = $this->container->get('entity_type.manager')->getStorage('skos_concept')->load('http://example.com/fruit/apple')->toUrl()->toString();
+    $request = Request::create($url);
+    /** @var \Drupal\Core\Routing\Router $router */
+    $router = \Drupal::service('router.no_access_checks');
+    $matched = $router->matchRequest($request);
+    // If this matched correctly using the RDF entity param converter, we should
+    // have the Concept entity in the result. Otherwise an exception is thrown
+    // and the test should fail.
+    $this->assertInstanceOf(ConceptInterface::class, $matched['skos_concept']);
   }
 
 }

--- a/tests/Kernel/RdfSkosKernelTestBase.php
+++ b/tests/Kernel/RdfSkosKernelTestBase.php
@@ -19,6 +19,7 @@ class RdfSkosKernelTestBase extends RdfKernelTestBase {
    */
   public static $modules = [
     'rdf_skos',
+    'rdf_skos_test',
   ];
 
   /**

--- a/tests/modules/rdf_skos_test/rdf_skos_test.info.yml
+++ b/tests/modules/rdf_skos_test/rdf_skos_test.info.yml
@@ -1,0 +1,8 @@
+name: 'RDF SKOS test module'
+type: module
+description: 'Test functionality for the RDF SKOS module.'
+package: Testing
+version: VERSION
+core: 8.x
+dependencies:
+  - rdf_skos:rdf_skos

--- a/tests/modules/rdf_skos_test/rdf_skos_test.services.yml
+++ b/tests/modules/rdf_skos_test/rdf_skos_test.services.yml
@@ -1,0 +1,5 @@
+services:
+  rdf_skos_test.active_graph_subscriber:
+    class: Drupal\rdf_skos_test\EventSubscriber\TestSkosActiveGraphSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/tests/modules/rdf_skos_test/src/EventSubscriber/TestSkosActiveGraphSubscriber.php
+++ b/tests/modules/rdf_skos_test/src/EventSubscriber/TestSkosActiveGraphSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_test\EventSubscriber;
+
+use Drupal\rdf_entity\ActiveGraphEvent;
+use Drupal\rdf_entity\Event\RdfEntityEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Test subscriber that indiscriminately sets some random graphs.
+ */
+class TestSkosActiveGraphSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Sets some dummy active graphs.
+   *
+   * @param \Drupal\rdf_entity\ActiveGraphEvent $event
+   *   The event object to process.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+   *   Thrown when the access is denied and redirects to user login page.
+   */
+  public function graphForEntityConvert(ActiveGraphEvent $event): void {
+    $event->setGraphs(['test_graph']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      RdfEntityEvents::GRAPH_ENTITY_CONVERT => ['graphForEntityConvert'],
+    ];
+  }
+
+}


### PR DESCRIPTION
While implementing OPENEUROPA-1295 on OE Content, two issues came to light:

* The entity param converter of RDF entity dispatches an event to determine the default graphs to look into. The RDF draft module subscribes to this event and responds with the `default` and `draft` graphs (this project doesn't use RDF Draft but OE Content does). However, for SKOS we don't have these graphs. So had to subscribe to the same event to ensure that for the SKOS entity types, we use the same graphs as normal.
* The new SKOS Concept entity reference field type needs a default widget and formatter plugin as it cannot use the default entity reference ones directly (since they are restricted to the entity reference field type). So we just create the new plugins and fully extend from the default ones.