### PR TITLE
OPENEUROPA-1690: Extensibility points for the Skos entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "drupal/core": "~8.6@alpha",
         "drupal/field_group": "^1.0",
         "drupal/rdf_entity": "1.0-alpha12",
-        "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1"
+        "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
+        "twig/twig": "~1.37.1"
     },
     "require-dev": {
         "composer/installers": "^1.2",

--- a/config/schema/rdf_skos.schema.yml
+++ b/config/schema/rdf_skos.schema.yml
@@ -27,17 +27,17 @@ entity_reference_selection.default:skos_concept:
       type: entity_reference_selection.skos_concept.concept_schemes
     field:
       type: mapping
-      label: Field information
+      label: 'Field information'
       mapping:
         field_name:
           type: string
-          label: The name of the field
+          label: 'The name of the field'
         entity_type:
           type: string
-          label: The entity type the field is on
+          label: 'The entity type the field is on'
         bundle:
           type: string
-          label: The entity type bundle the field is on
+          label: 'The entity type bundle the field is on'
         concept_schemes:
           type: entity_reference_selection.skos_concept.concept_schemes
 

--- a/config/schema/rdf_skos.schema.yml
+++ b/config/schema/rdf_skos.schema.yml
@@ -24,8 +24,26 @@ entity_reference_selection.default:skos_concept:
   label: 'SKOS Concept handler settings'
   mapping:
     concept_schemes:
-      type: sequence
-      label: 'The concept schemes to filter by'
-      sequence:
-        type: string
-        label: 'The Concept Scheme URI'
+      type: entity_reference_selection.skos_concept.concept_schemes
+    field:
+      type: mapping
+      label: Field information
+      mapping:
+        field_name:
+          type: string
+          label: The name of the field
+        entity_type:
+          type: string
+          label: The entity type the field is on
+        bundle:
+          type: string
+          label: The entity type bundle the field is on
+        concept_schemes:
+          type: entity_reference_selection.skos_concept.concept_schemes
+
+entity_reference_selection.skos_concept.concept_schemes:
+  type: sequence
+  label: 'The concept schemes to filter by'
+  sequence:
+    type: string
+    label: 'The Concept Scheme URI'

--- a/src/Event/SkosPredicateMappingEvent.php
+++ b/src/Event/SkosPredicateMappingEvent.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event dispatched to gather custom predicate mappings for SKOS entities.
+ */
+class SkosPredicateMappingEvent extends Event {
+
+  /**
+   * The predicate mapping.
+   *
+   * @var array
+   */
+  protected $mapping = [];
+
+  /**
+   * The entity type ID.
+   *
+   * @var string
+   */
+  protected $entityTypeId;
+
+  /**
+   * SkosPredicateMappingEvent constructor.
+   *
+   * @param string $entityTypeId
+   *   The entity type ID.
+   */
+  public function __construct(string $entityTypeId) {
+    $this->entityTypeId = $entityTypeId;
+  }
+
+  /**
+   * Returns the predicate mapping.
+   *
+   * @return array
+   *   The mapping.
+   */
+  public function getMapping(): array {
+    return $this->mapping;
+  }
+
+  /**
+   * Sets the predicate mapping.
+   *
+   * @param array $mapping
+   *   The mapping.
+   */
+  public function setMapping(array $mapping): void {
+    $this->mapping = $mapping;
+  }
+
+  /**
+   * Returns the entity type ID the mapping applies to.
+   *
+   * @return string
+   *   The entity type ID.
+   */
+  public function getEntityTypeId(): string {
+    return $this->entityTypeId;
+  }
+
+}

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -83,7 +83,9 @@ class SkosConceptSelection extends DefaultSelection {
       $settings['handler_settings']['concept_schemes'] = $concept_schemes;
     }
 
-    // Add field information that can be used in the selection handler.
+    // Add field information that can be used in the selection handler. This
+    // comes from the actual SkosConceptEntityReferenceItem and we need it so
+    // that the selection plugin query builder can receive this information.
     $field = $form_state->get('field');
     if ($field instanceof FieldConfigInterface) {
       $settings['handler_settings']['field'] = [

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -6,6 +6,7 @@ namespace Drupal\rdf_skos\Plugin\EntityReferenceSelection;
 
 use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Field\FieldConfigInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -28,6 +29,9 @@ class SkosConceptSelection extends DefaultSelection {
     return [
       // Empty array means allow all.
       'concept_schemes' => [],
+        // In case the plugin is used in a reference field, we can store some
+        // info about it.
+      'field' => [],
     ] + parent::defaultConfiguration();
   }
 
@@ -77,8 +81,20 @@ class SkosConceptSelection extends DefaultSelection {
     if ($concept_schemes) {
       $concept_schemes = array_values($concept_schemes);
       $settings['handler_settings']['concept_schemes'] = $concept_schemes;
-      $form_state->setValue('settings', $settings);
     }
+
+    // Add field information that can be used in the selection handler.
+    $field = $form_state->get('field');
+    if ($field instanceof FieldConfigInterface) {
+      $settings['handler_settings']['field'] = [
+        'field_name' => $field->getName(),
+        'entity_type' => $field->getTargetEntityTypeId(),
+        'bundle' => $field->getTargetBundle(),
+        'concept_schemes' => $concept_schemes,
+      ];
+    }
+
+    $form_state->setValue('settings', $settings);
   }
 
   /**
@@ -87,6 +103,12 @@ class SkosConceptSelection extends DefaultSelection {
   protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS'): QueryInterface {
     $query = parent::buildEntityQuery($match, $match_operator);
     $configuration = $this->getConfiguration();
+    if (!empty($configuration['field'])) {
+      // Allow query alterations when used for a reference field.
+      $query->addTag('skos_concept_field_selection_plugin');
+      $query->addMetaData('field', $configuration['field']);
+    }
+
     $concept_schemes = $configuration['concept_schemes'];
     if (empty($concept_schemes)) {
       return $query;

--- a/src/Plugin/Field/FieldType/SkosConceptEntityReferenceItem.php
+++ b/src/Plugin/Field/FieldType/SkosConceptEntityReferenceItem.php
@@ -85,6 +85,9 @@ class SkosConceptEntityReferenceItem extends EntityReferenceItem {
     ];
 
     $handler = $selection_manager->getSelectionHandler($field);
+    // Set the current field config in the form state to make it available in
+    // selection plugin.
+    $form_state->set('field', $field);
     $form['handler']['handler_settings'] += $handler->buildConfigurationForm([], $form_state);
 
     return $form;

--- a/src/RdfSkosFieldHandler.php
+++ b/src/RdfSkosFieldHandler.php
@@ -7,11 +7,17 @@ namespace Drupal\rdf_skos;
 use Drupal\rdf_entity\Exception\NonExistingFieldPropertyException;
 use Drupal\rdf_entity\RdfFieldHandler;
 use Drupal\rdf_entity\RdfFieldHandlerInterface;
+use Drupal\rdf_skos\Event\SkosPredicateMappingEvent;
 
 /**
  * RDF field handler for SKOS entities.
  */
 class RdfSkosFieldHandler extends RdfFieldHandler {
+
+  /**
+   * Event name dispatched to gather predicate mappings for SKOS entities.
+   */
+  const PREDICATE_MAPPING_EVENT = 'rdf_skos_field_handler.predicate_mapping';
 
   /**
    * {@inheritdoc}
@@ -218,7 +224,11 @@ class RdfSkosFieldHandler extends RdfFieldHandler {
       ],
     ];
 
-    return $mapping[$entity_type_id];
+    $event = new SkosPredicateMappingEvent($entity_type_id);
+    $event->setMapping($mapping[$entity_type_id]);
+    $this->eventDispatcher->dispatch(self::PREDICATE_MAPPING_EVENT, $event);
+
+    return $event->getMapping();
   }
 
 }

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\rdf_skos\Kernel;
 
-use Drupal\field\Tests\EntityReference\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
 
 /**
  * Tests the SKOS entity reference field.

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -22,7 +22,12 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
     // Enable both graphs.
     $this->enableGraph('fruit');
     $this->enableGraph('vegetables');
+  }
 
+  /**
+   * Tests the SKOS Concept reference fields.
+   */
+  public function testReferenceFields(): void {
     // Create a reference field to Fruit.
     $this->createEntityReferenceField(
       'entity_test',
@@ -53,12 +58,7 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
         ],
       ]
     );
-  }
 
-  /**
-   * Tests the SKOS Concept reference fields.
-   */
-  public function testReferenceFields(): void {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $entity_type_manager = $this->container->get('entity_type.manager');
 
@@ -81,6 +81,56 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
     $this->assertEquals(0, $violations->count());
     $entity->set('field_fruits_veggies', 'http://example.com/vegetables/potato');
     $violations = $entity->field_fruits_veggies->validate();
+    $this->assertCount(0, $violations);
+  }
+
+  /**
+   * Test reference field query alter.
+   *
+   * Tests that fields can be configured in a way that their selection plugin
+   * is alterable.
+   */
+  public function testReferenceFieldQueryAlter() {
+    // Create a reference field to Fruit that is alterable.
+    $this->createEntityReferenceField(
+      'entity_test',
+      'entity_test',
+      'field_fruit',
+      'Fruit',
+      'skos_concept',
+      'default',
+      [
+        'concept_schemes' => [
+          'http://example.com/fruit',
+        ],
+        'field' => [
+          'field_name' => 'field_fruit',
+          'entity_type' => 'entity_test',
+          'bundle' => 'entity_test',
+          'concept_schemes' => [
+            'http://example.com/fruit',
+          ],
+        ],
+      ]
+    );
+
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+
+    /** @var \Drupal\entity_test\Entity\EntityTest $entity */
+    $entity = $entity_type_manager->getStorage('entity_test')
+      ->create(['type' => 'entity_test']);
+
+    // The fruit field should only reference the "pear" fruit as it's the only
+    // one that is related to "apple".
+    // @see rdf_skos_test_query_skos_concept_field_selection_plugin_alter()
+    $entity->set('field_fruit', 'http://example.com/fruit/apple');
+    $violations = $entity->field_fruit->validate();
+    $this->assertCount(1, $violations);
+    $this->assertEquals(t('This entity (%type: %id) cannot be referenced.', ['%type' => 'skos_concept', '%id' => 'http://example.com/fruit/apple']), $violations[0]->getMessage());
+
+    $entity->set('field_fruit', 'http://example.com/fruit/pear');
+    $violations = $entity->field_fruit->validate();
     $this->assertCount(0, $violations);
   }
 

--- a/tests/modules/rdf_skos_test/rdf_skos_test.module
+++ b/tests/modules/rdf_skos_test/rdf_skos_test.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * The RDF Skos test module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Database\Query\AlterableInterface;
+
+/**
+ * Implements hook_query_QUERY_TAG_alter().
+ *
+ * Alters the entity_test field_fruit field.
+ */
+function rdf_skos_test_query_skos_concept_field_selection_plugin_alter(AlterableInterface $query) {
+  $field_info = $query->getMetaData('field');
+  if (!$field_info) {
+    return;
+  }
+
+  if ($field_info['field_name'] === 'field_fruit' && count($field_info['concept_schemes']) === 1 && $field_info['concept_schemes'][0] === 'http://example.com/fruit') {
+    // Only apple related fruit.
+    $query->condition('related', 'http://example.com/fruit/apple');
+  }
+}


### PR DESCRIPTION
As part of OPENEUROPA-1690 we need to make the RDF Skos slightly more extensible to allow custom predicate mappings for various types of skos concepts specific to the EC.

2 main things happen in this PR:

* Dispatching an event to allow others to supply predicate mapping info
* Adding query tag and field info to the custom Skos concept entity reference field and selection plugin. Clients can query alter based on the tag and have relevant info to apply alterations