### PR TITLE
OPENEUROPA-1897: Use ci image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:7.1
     environment:
       - DOCUMENT_ROOT=/test/rdf_skos
   mysql:
@@ -20,7 +20,7 @@ services:
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:7.1
     volumes:
       - /cache:/cache
     commands:
@@ -28,7 +28,7 @@ pipeline:
 
   composer-update-lowest:
     group: post-prepare
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:7.1
     volumes:
       - /cache:/cache
     commands:
@@ -38,19 +38,19 @@ pipeline:
         COMPOSER_BOUNDARY: lowest
 
   site-install:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:7.1
     commands:
       - ./vendor/bin/run drupal:site-install
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:7.1
     commands:
       - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:7.1
     commands:
       - ./vendor/bin/phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "composer/installers": "^1.5",
-        "consolidation/robo" : "^1.2.2",
+        "consolidation/robo" : "~1.4",
         "cweagans/composer-patches": "~1.0",
         "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
@@ -24,9 +24,9 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/task-runner": "~1.0@beta",
+        "openeuropa/task-runner": "~1.0.0-beta5",
         "phpunit/phpunit": "~6.0",
-        "symfony/dom-crawler": "~3.0"
+        "symfony/dom-crawler": "~3.4"
     },
     "suggest": {
         "drupal/console": "^1"


### PR DESCRIPTION
## OPENEUROPA-1897
### Description

Use CI image on drone builds.

### Change log

- Added:
- Changed: Use CI image on drone builds.

- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

