### PR TITLE
MULTISITE-21706: Update field_group to ^3.0@rc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "drupal/core": "^8.7",
-        "drupal/field_group": "^1.0",
+        "drupal/field_group": "^3.0@rc",
         "drupal/rdf_entity": "1.0-alpha12",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
         "php": "^7.1"


### PR DESCRIPTION
From the project page: https://www.drupal.org/project/field_group

> For Drupal 8.3 and higher, use the fieldgroup 8.3 branch. When you still use a drupal version lower then 8.3, use the fieldgroup 8.1 branch

Same should happen for openeuropa/oe_content which depends on openeuropa/rdf_skos. So it's dependency should go onto 0.4.0.