### PR TITLE
OPENEUROPA-3158: Skos concept reference item list class.

### DIFF
--- a/config/schema/rdf_skos.schema.yml
+++ b/config/schema/rdf_skos.schema.yml
@@ -86,3 +86,11 @@ views.filter.skos_concept_reference_id:
 
 views.filter_value.skos_concept_reference_id:
   type: views.filter_value.in_operator
+
+field.value.skos_concept_entity_reference:
+  type: mapping
+  label: 'Default value'
+  mapping:
+    target_id:
+      type: string
+      label: 'Value'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 #    ports:
 #      - 3306:3306
   sparql:
-    image: openeuropa/triple-store-dev
+    image: openeuropa/triple-store-dev:1.2.0
     environment:
     - SPARQL_UPDATE=true
     - DBA_PASSWORD=dba

--- a/src/Plugin/Field/FieldType/SkosConceptEntityReferenceItem.php
+++ b/src/Plugin/Field/FieldType/SkosConceptEntityReferenceItem.php
@@ -20,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   category = @Translation("SKOS"),
  *   default_widget = "skos_concept_entity_reference_autocomplete",
  *   default_formatter = "skos_concept_entity_reference_label",
- *   list_class = "\Drupal\Core\Field\EntityReferenceFieldItemList",
+ *   list_class = "\Drupal\rdf_skos\Plugin\Field\SkosConceptReferenceFieldItemList",
  * )
  */
 class SkosConceptEntityReferenceItem extends EntityReferenceItem {

--- a/src/Plugin/Field/SkosConceptReferenceFieldItemList.php
+++ b/src/Plugin/Field/SkosConceptReferenceFieldItemList.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\Plugin\Field;
+
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldItemList;
+
+/**
+ * Field item list class for the SKOS concept reference field item.
+ */
+class SkosConceptReferenceFieldItemList extends FieldItemList implements EntityReferenceFieldItemListInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConstraints() {
+    $constraints = parent::getConstraints();
+    $constraint_manager = $this->getTypedDataManager()->getValidationConstraintManager();
+    $constraints[] = $constraint_manager->create('ValidReference', []);
+    return $constraints;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function referencedEntities() {
+    if ($this->isEmpty()) {
+      return [];
+    }
+
+    $target_entities = $ids = [];
+    foreach ($this->list as $delta => $item) {
+      if ($item->target_id !== NULL) {
+        $ids[$delta] = $item->target_id;
+      }
+    }
+
+    if ($ids) {
+      $entities = \Drupal::entityTypeManager()->getStorage('skos_concept')->loadMultiple($ids);
+      foreach ($ids as $delta => $target_id) {
+        if (isset($entities[$target_id])) {
+          $target_entities[$delta] = $entities[$target_id];
+        }
+      }
+
+      ksort($target_entities);
+    }
+
+    return $target_entities;
+  }
+
+}


### PR DESCRIPTION
In this PR we use our own Skos Concept reference list class because the entity reference item one makes some assumptions that don;t work for SKOS regarding the default values. For SKOS it's enough to simply store the target_id instead of UUID which doesn't exist.