### PR TITLE
OPENEUROPA-3409: Pluggable subsets of concepts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.{json,lock}]
+indent_size = 4

--- a/config/schema/rdf_skos.schema.yml
+++ b/config/schema/rdf_skos.schema.yml
@@ -25,6 +25,9 @@ entity_reference_selection.default:skos_concept:
   mapping:
     concept_schemes:
       type: entity_reference_selection.skos_concept.concept_schemes
+    concept_subset:
+      type: string
+      label: 'The ID of the ConceptSubset plugin'
     field:
       type: mapping
       label: 'Field information'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,27 @@ services:
     ports:
       - "8890:8890"
 
+  # If you would like to see what is going on you can run the following on your host:
+  # docker run --rm -p 4444:4444 -p 5900:5900 --network="host" selenium/standalone-chrome-debug:latest
+  # Newer version of this image might run into this issue:
+  # @link https://github.com/elgalu/docker-selenium/issues/20
+  selenium:
+    image: selenium/standalone-chrome-debug:3.141.59-oxygen
+    expose:
+      - '4444'
+    environment:
+      - DISPLAY=:99
+      - SE_OPTS=-debug
+      - SCREEN_WIDTH=1280
+      - SCREEN_HEIGHT=800
+      - VNC_NO_PASSWORD=1
+    ports:
+      - '4444:4444'
+      - "5900:5900"
+    volumes:
+      - /dev/shm:/dev/shm
+    shm_size: 2g
+
 #### Mac users: uncomment the "volumes" key to enable the NFS file sharing. You can find more information about Docker for Mac here: https://github.com/openeuropa/openeuropa/blob/master/docs/starting/tooling.md#using-docker-on-macos
 
 #volumes:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
     <env name="SIMPLETEST_BASE_URL" value="${drupal.base_url}"/>
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
     <env name="SIMPLETEST_SPARQL_DB" value="sparql://${drupal.sparql.host}:${drupal.sparql.port}/"/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["${selenium.browser}", null, "${selenium.host}:${selenium.port}/wd/hub"]'/>
   </php>
   <testsuites>
     <testsuite>

--- a/rdf_skos.module
+++ b/rdf_skos.module
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\field\FieldStorageConfigInterface;
 
 /**
@@ -27,4 +28,32 @@ function rdf_skos_field_views_data_alter(array &$data, FieldStorageConfigInterfa
       }
     }
   }
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Provide the base field definitions of all the predicate mapping concept
+ * subset plugins.
+ */
+function rdf_skos_entity_base_field_info(EntityTypeInterface $entity_type) {
+  if ($entity_type->id() !== 'skos_concept') {
+    return [];
+  }
+
+  $fields = [];
+
+  /** @var \Drupal\rdf_skos\ConceptSubsetPluginManagerInterface $manager */
+  $manager = \Drupal::service('plugin.manager.concept_subset');
+  $definitions = $manager->getPredicateMappingDefinitions();
+  foreach ($definitions as $id => $definition) {
+    /** @var \Drupal\rdf_skos\Plugin\PredicateMapperInterface $plugin */
+    $plugin = $manager->createInstance($id);
+    $base_fields = $plugin->getBaseFieldDefinitions();
+    if ($base_fields) {
+      $fields += $base_fields;
+    }
+  }
+
+  return $fields;
 }

--- a/rdf_skos.services.yml
+++ b/rdf_skos.services.yml
@@ -10,6 +10,7 @@ services:
   rdf_skos.sparql.field_handler:
     class: Drupal\rdf_skos\RdfSkosFieldHandler
     parent: sparql.field_handler
+    arguments: ['@plugin.manager.concept_subset']
   rdf_skos.active_graph_subscriber:
     class: Drupal\rdf_skos\EventSubscriber\SkosActiveGraphSubscriber
     arguments: ['@entity_type.manager', '@rdf_skos.sparql.graph_handler']
@@ -18,3 +19,6 @@ services:
   rdf_skos.skos_graph_configurator:
     class: Drupal\rdf_skos\SkosGraphConfigurator
     arguments: ['@config.factory']
+  plugin.manager.concept_subset:
+    class: Drupal\rdf_skos\ConceptSubsetPluginManager
+    parent: default_plugin_manager

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -40,6 +40,11 @@ drupal:
           namespace: 'Drupal\Driver\Database\sparql'
           driver: 'sparql'
 
+selenium:
+  host: "http://selenium"
+  port: "4444"
+  browser: "chrome"
+
 commands:
   drupal:site-setup:
     - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/rdf_skos" }

--- a/src/Annotation/ConceptSubset.php
+++ b/src/Annotation/ConceptSubset.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines concept_subset annotation object.
+ *
+ * @Annotation
+ */
+class ConceptSubset extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $title;
+
+  /**
+   * The description of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $description;
+
+  /**
+   * Whether this plugin maps predicates to Drupal base fields.
+   *
+   * Optional.
+   *
+   * @var bool
+   */
+  public $predicate_mapping;
+
+  /**
+   * The concept schemes this plugin should work with.
+   *
+   * Optional. Leaving empty means it works with all concept schemes.
+   *
+   * @var array
+   */
+  public $concept_schemes;
+
+}

--- a/src/Annotation/ConceptSubset.php
+++ b/src/Annotation/ConceptSubset.php
@@ -7,7 +7,7 @@ namespace Drupal\rdf_skos\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
- * Defines concept_subset annotation object.
+ * Defines the concept_subset annotation object.
  *
  * @Annotation
  */

--- a/src/ConceptSubsetInterface.php
+++ b/src/ConceptSubsetInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+
+/**
+ * Interface for concept_subset plugins.
+ */
+interface ConceptSubsetInterface {
+
+  /**
+   * Returns the translated plugin label.
+   *
+   * @return string
+   *   The translated title.
+   */
+  public function label();
+
+  /**
+   * Alters the query of the selection plugin.
+   *
+   * @param \Drupal\Core\Entity\Query\QueryInterface $query
+   *   The query to alter.
+   * @param string $match_operator
+   *   The matching operator.
+   * @param array $concept_schemes
+   *   The selected concept schemes.
+   * @param string|null $match
+   *   The value to match.
+   */
+  public function alterQuery(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void;
+
+}

--- a/src/ConceptSubsetInterface.php
+++ b/src/ConceptSubsetInterface.php
@@ -17,7 +17,7 @@ interface ConceptSubsetInterface {
    * @return string
    *   The translated title.
    */
-  public function label();
+  public function label(): string;
 
   /**
    * Alters the query of the selection plugin.

--- a/src/ConceptSubsetPluginBase.php
+++ b/src/ConceptSubsetPluginBase.php
@@ -14,7 +14,7 @@ abstract class ConceptSubsetPluginBase extends PluginBase implements ConceptSubs
   /**
    * {@inheritdoc}
    */
-  public function label() {
+  public function label(): string {
     // Cast the label to a string since it is a TranslatableMarkup object.
     return (string) $this->pluginDefinition['label'];
   }

--- a/src/ConceptSubsetPluginBase.php
+++ b/src/ConceptSubsetPluginBase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Base class for concept_subset plugins.
+ */
+abstract class ConceptSubsetPluginBase extends PluginBase implements ConceptSubsetInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+    // Cast the label to a string since it is a TranslatableMarkup object.
+    return (string) $this->pluginDefinition['label'];
+  }
+
+}

--- a/src/ConceptSubsetPluginManager.php
+++ b/src/ConceptSubsetPluginManager.php
@@ -14,7 +14,7 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 class ConceptSubsetPluginManager extends DefaultPluginManager implements ConceptSubsetPluginManagerInterface {
 
   /**
-   * Constructs ConceptSubsetPluginManager object.
+   * Constructs a ConceptSubsetPluginManager object.
    *
    * @param \Traversable $namespaces
    *   An object that implements \Traversable which contains the root paths
@@ -54,7 +54,7 @@ class ConceptSubsetPluginManager extends DefaultPluginManager implements Concept
   /**
    * {@inheritdoc}
    */
-  public function getApplicableDefinitionsDefinitions(array $concept_schemes): array {
+  public function getApplicableDefinitions(array $concept_schemes): array {
     $plugin_ids = [];
     foreach ($concept_schemes as $concept_scheme) {
       $definitions = $this->getDefinitionsForConceptScheme($concept_scheme);
@@ -76,7 +76,7 @@ class ConceptSubsetPluginManager extends DefaultPluginManager implements Concept
   }
 
   /**
-   * Gets the plugin definition that applies to a single concept scheme.
+   * Gets the plugin definitions that apply to a single concept scheme.
    *
    * @param string $concept_scheme
    *   The concept scheme ID.

--- a/src/ConceptSubsetPluginManager.php
+++ b/src/ConceptSubsetPluginManager.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * ConceptSubset plugin manager.
+ */
+class ConceptSubsetPluginManager extends DefaultPluginManager implements ConceptSubsetPluginManagerInterface {
+
+  /**
+   * Constructs ConceptSubsetPluginManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/ConceptSubset',
+      $namespaces,
+      $module_handler,
+      'Drupal\rdf_skos\ConceptSubsetInterface',
+      'Drupal\rdf_skos\Annotation\ConceptSubset'
+    );
+    $this->alterInfo('concept_subset_info');
+    $this->setCacheBackend($cache_backend, 'concept_subset_plugins');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPredicateMappingDefinitions(): array {
+    $definitions = $this->getDefinitions();
+    $predicate_mappers = [];
+    foreach ($definitions as $id => $definition) {
+      if (isset($definition['predicate_mapping']) && (bool) $definition['predicate_mapping']) {
+        $predicate_mappers[$id] = $definition;
+      }
+    }
+
+    return $predicate_mappers;
+  }
+
+}

--- a/src/ConceptSubsetPluginManager.php
+++ b/src/ConceptSubsetPluginManager.php
@@ -55,24 +55,14 @@ class ConceptSubsetPluginManager extends DefaultPluginManager implements Concept
    * {@inheritdoc}
    */
   public function getApplicableDefinitions(array $concept_schemes): array {
-    $plugin_ids = [];
+    $definitions_by_scheme = [];
     foreach ($concept_schemes as $concept_scheme) {
-      $definitions = $this->getDefinitionsForConceptScheme($concept_scheme);
-      $ids = $definitions ? array_keys($definitions) : [];
-      $plugin_ids[$concept_scheme] = $ids;
+      $definitions_by_scheme[$concept_scheme] = $this->getDefinitionsForConceptScheme($concept_scheme);
     }
-
-    if (!$plugin_ids) {
+    if (!$definitions_by_scheme) {
       return [];
     }
-
-    $plugin_ids = count($plugin_ids) === 1 ? reset($plugin_ids) : call_user_func_array('array_intersect', $plugin_ids);
-    $definitions = [];
-    foreach ($plugin_ids as $plugin_id) {
-      $definitions[$plugin_id] = $this->getDefinition($plugin_id);
-    }
-
-    return $definitions;
+    return count($definitions_by_scheme) === 1 ? reset($definitions_by_scheme) : call_user_func_array('array_intersect_key', $definitions_by_scheme);
   }
 
   /**

--- a/src/ConceptSubsetPluginManager.php
+++ b/src/ConceptSubsetPluginManager.php
@@ -51,4 +51,55 @@ class ConceptSubsetPluginManager extends DefaultPluginManager implements Concept
     return $predicate_mappers;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getApplicableDefinitionsDefinitions(array $concept_schemes): array {
+    $plugin_ids = [];
+    foreach ($concept_schemes as $concept_scheme) {
+      $definitions = $this->getDefinitionsForConceptScheme($concept_scheme);
+      $ids = $definitions ? array_keys($definitions) : [];
+      $plugin_ids[$concept_scheme] = $ids;
+    }
+
+    if (!$plugin_ids) {
+      return [];
+    }
+
+    $plugin_ids = count($plugin_ids) === 1 ? reset($plugin_ids) : call_user_func_array('array_intersect', $plugin_ids);
+    $definitions = [];
+    foreach ($plugin_ids as $plugin_id) {
+      $definitions[$plugin_id] = $this->getDefinition($plugin_id);
+    }
+
+    return $definitions;
+  }
+
+  /**
+   * Gets the plugin definition that applies to a single concept scheme.
+   *
+   * @param string $concept_scheme
+   *   The concept scheme ID.
+   *
+   * @return array
+   *   The definitions.
+   */
+  protected function getDefinitionsForConceptScheme(string $concept_scheme): array {
+    $all_definitions = $this->getDefinitions();
+    $definitions = [];
+    foreach ($all_definitions as $id => $definition) {
+      if (!isset($definition['concept_schemes'])) {
+        // Include the ones without any limitation.
+        $definitions[$id] = $definition;
+        continue;
+      }
+
+      if (in_array($concept_scheme, $definition['concept_schemes'])) {
+        $definitions[$id] = $definition;
+      }
+    }
+
+    return $definitions;
+  }
+
 }

--- a/src/ConceptSubsetPluginManager.php
+++ b/src/ConceptSubsetPluginManager.php
@@ -43,7 +43,7 @@ class ConceptSubsetPluginManager extends DefaultPluginManager implements Concept
     $definitions = $this->getDefinitions();
     $predicate_mappers = [];
     foreach ($definitions as $id => $definition) {
-      if (isset($definition['predicate_mapping']) && (bool) $definition['predicate_mapping']) {
+      if (isset($definition['predicate_mapping']) && $definition['predicate_mapping']) {
         $predicate_mappers[$id] = $definition;
       }
     }

--- a/src/ConceptSubsetPluginManagerInterface.php
+++ b/src/ConceptSubsetPluginManagerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+
+/**
+ * Represents a concept subset plugin manager.
+ */
+interface ConceptSubsetPluginManagerInterface extends PluginManagerInterface {
+
+  /**
+   * Returns all the plugin definitions that map predicates to Drupal fields.
+   *
+   * @return array
+   *   The definitions.
+   */
+  public function getPredicateMappingDefinitions(): array;
+
+}

--- a/src/ConceptSubsetPluginManagerInterface.php
+++ b/src/ConceptSubsetPluginManagerInterface.php
@@ -20,7 +20,7 @@ interface ConceptSubsetPluginManagerInterface extends PluginManagerInterface {
   public function getPredicateMappingDefinitions(): array;
 
   /**
-   * Returns all the plugin definitions apply to a concept scheme.
+   * Returns all the plugin definitions that apply to a set of concept schemes.
    *
    * @param array $concept_schemes
    *   The  selected concept scheme IDs.
@@ -28,6 +28,6 @@ interface ConceptSubsetPluginManagerInterface extends PluginManagerInterface {
    * @return array
    *   The definitions.
    */
-  public function getApplicableDefinitionsDefinitions(array $concept_schemes): array;
+  public function getApplicableDefinitions(array $concept_schemes): array;
 
 }

--- a/src/ConceptSubsetPluginManagerInterface.php
+++ b/src/ConceptSubsetPluginManagerInterface.php
@@ -19,4 +19,15 @@ interface ConceptSubsetPluginManagerInterface extends PluginManagerInterface {
    */
   public function getPredicateMappingDefinitions(): array;
 
+  /**
+   * Returns all the plugin definitions apply to a concept scheme.
+   *
+   * @param array $concept_schemes
+   *   The  selected concept scheme IDs.
+   *
+   * @return array
+   *   The definitions.
+   */
+  public function getApplicableDefinitionsDefinitions(array $concept_schemes): array;
+
 }

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -86,6 +86,10 @@ class SkosConceptSelection extends DefaultSelection {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $form = parent::buildConfigurationForm($form, $form_state);
 
+    // We do not support sorting or auto-creation of values.
+    $form['auto_create']['#access'] = FALSE;
+    $form['sort']['#access'] = FALSE;
+
     $configuration = $this->getConfiguration();
 
     $form['concept_schemes'] = [

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -215,7 +215,7 @@ class SkosConceptSelection extends DefaultSelection {
    *   The form element.
    */
   protected function buildConceptSubsetElement(array $form, FormStateInterface $form_state, array $concept_schemes): array {
-    $definitions = $this->subsetManager->getApplicableDefinitionsDefinitions($concept_schemes);
+    $definitions = $this->subsetManager->getApplicableDefinitions($concept_schemes);
 
     if (!$definitions) {
       return [];
@@ -229,7 +229,7 @@ class SkosConceptSelection extends DefaultSelection {
     return [
       '#type' => 'select',
       '#title' => $this->t('Concept subset'),
-      '#description' => $this->t('The concept subsets you would like this selection to filter by.'),
+      '#description' => $this->t('The concept subset you would like this selection to filter by.'),
       '#options' => $options,
       '#default_value' => $this->getConfiguration()['concept_subset'],
     ];

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -42,8 +42,6 @@ class SkosConceptSelection extends DefaultSelection {
     $form = parent::buildConfigurationForm($form, $form_state);
 
     $configuration = $this->getConfiguration();
-    $concept_scheme_ids = $this->entityManager->getStorage('skos_concept_scheme')->getQuery()
-      ->execute();
 
     $form['concept_schemes'] = [
       '#type' => 'select',
@@ -54,15 +52,10 @@ class SkosConceptSelection extends DefaultSelection {
       '#multiple' => TRUE,
     ];
 
-    if (empty($concept_scheme_ids)) {
-      return $form;
-    }
+    $options = $this->prepareConceptSchemeOptions();
 
-    /** @var \Drupal\rdf_skos\Entity\ConceptSchemeInterface[] $concept_schemes */
-    $concept_schemes = $this->entityManager->getStorage('skos_concept_scheme')->loadMultiple($concept_scheme_ids);
-    $options = [];
-    foreach ($concept_schemes as $concept_scheme) {
-      $options[$concept_scheme->id()] = $concept_scheme->getTitle();
+    if (empty($options)) {
+      return $form;
     }
 
     $form['concept_schemes']['#options'] = $options;
@@ -118,6 +111,32 @@ class SkosConceptSelection extends DefaultSelection {
     $query->condition('in_scheme', $concept_schemes, 'IN');
 
     return $query;
+  }
+
+  /**
+   * Prepares the options for the concept scheme select element.
+   *
+   * @return array
+   *   The options.
+   */
+  protected function prepareConceptSchemeOptions(): array {
+    $ids = $this->entityTypeManager->getStorage('skos_concept_scheme')
+      ->getQuery()
+      ->execute();
+
+    if (!$ids) {
+      return [];
+    }
+
+    /** @var \Drupal\rdf_skos\Entity\ConceptSchemeInterface[] $concept_schemes */
+    $concept_schemes = $this->entityTypeManager->getStorage('skos_concept_scheme')->loadMultiple($ids);
+
+    $options = [];
+    foreach ($concept_schemes as $concept_scheme) {
+      $options[$concept_scheme->id()] = $concept_scheme->getTitle();
+    }
+
+    return $options;
   }
 
 }

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -212,7 +212,7 @@ class SkosConceptSelection extends DefaultSelection {
    * @return array
    *   The form element.
    */
-  protected function buildConceptSubsetElement(array $form, FormStateInterface $form_state, array $concept_schemes) {
+  protected function buildConceptSubsetElement(array $form, FormStateInterface $form_state, array $concept_schemes): array {
     $all_definitions = $this->subsetManager->getDefinitions();
     $options = [];
     foreach ($all_definitions as $id => $definition) {
@@ -252,7 +252,7 @@ class SkosConceptSelection extends DefaultSelection {
    * @param string|null $match
    *   The value to match.
    */
-  protected function applyConceptSubset(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL) {
+  protected function applyConceptSubset(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void {
     $configuration = $this->getConfiguration();
     if (!$configuration['concept_subset']) {
       return;

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -213,22 +213,15 @@ class SkosConceptSelection extends DefaultSelection {
    *   The form element.
    */
   protected function buildConceptSubsetElement(array $form, FormStateInterface $form_state, array $concept_schemes): array {
-    $all_definitions = $this->subsetManager->getDefinitions();
-    $options = [];
-    foreach ($all_definitions as $id => $definition) {
-      if (!isset($definition['concept_schemes'])) {
-        // Include the ones without any limitation.
-        $options[$id] = $definition['label'];
-        continue;
-      }
+    $definitions = $this->subsetManager->getApplicableDefinitionsDefinitions($concept_schemes);
 
-      if (array_intersect($concept_schemes, $definition['concept_schemes'])) {
-        $options[$id] = $definition['label'];
-      }
+    if (!$definitions) {
+      return [];
     }
 
-    if (!$options) {
-      return [];
+    $options = [];
+    foreach ($definitions as $id => $definition) {
+      $options[$id] = $definition['label'];
     }
 
     return [

--- a/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
+++ b/src/Plugin/EntityReferenceSelection/SkosConceptSelection.php
@@ -101,20 +101,18 @@ class SkosConceptSelection extends DefaultSelection {
       '#ajax' => TRUE,
     ];
 
-    $concept_schemes = $configuration['concept_schemes'] ?
-      $configuration['concept_schemes'] :
-      $form_state->getValue(['settings', 'handler_settings', 'concept_schemes']);
+    $options = $this->prepareConceptSchemeOptions();
+
+    if (empty($options)) {
+      return $form;
+    }
+
+    $concept_schemes = $configuration['concept_schemes'];
     if ($concept_schemes) {
       $subset_element = $this->buildConceptSubsetElement($form, $form_state, $concept_schemes);
       if ($subset_element) {
         $form['concept_subset'] = $subset_element;
       }
-    }
-
-    $options = $this->prepareConceptSchemeOptions();
-
-    if (empty($options)) {
-      return $form;
     }
 
     $form['concept_schemes']['#options'] = $options;

--- a/src/Plugin/PredicateMapperInterface.php
+++ b/src/Plugin/PredicateMapperInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos\Plugin;
+
+/**
+ * Interface for ConceptSubset plugins that need to map predicates.
+ *
+ * Sometimes, in order to determine a concept subset, new custom predicates
+ * need to be mapped to the triple data that does not technically adhere to
+ * the SKOS notation.
+ *
+ * This mapping needs to be done between a predicate and a base field on the
+ * Drupal entity that will be hydrated with the data value.
+ */
+interface PredicateMapperInterface {
+
+  /**
+   * Returns an array of predicate mappings.
+   *
+   * @return array
+   *   The predicate mappings.
+   */
+  public function getPredicateMapping(): array;
+
+  /**
+   * Returns the base field definitions that map to the predicates.
+   *
+   * @return array
+   *   The base field definitions.
+   */
+  public function getBaseFieldDefinitions(): array;
+
+}

--- a/tests/FunctionalJavascript/SkosConceptSelectionFormTest.php
+++ b/tests/FunctionalJavascript/SkosConceptSelectionFormTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\rdf_skos\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\rdf_entity\Traits\RdfDatabaseConnectionTrait;
+use Drupal\Tests\rdf_skos\Traits\SkosImportTrait;
+
+/**
+ * Tests the SKOS Concept entity reference selection plugin form.
+ */
+class SkosConceptSelectionFormTest extends WebDriverTestBase {
+
+  use RdfDatabaseConnectionTrait;
+  use SkosImportTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'field_ui',
+    'field',
+    'rdf_entity',
+    'rdf_skos',
+    'rdf_skos_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp($import_test_views = TRUE) {
+    parent::setUp();
+    $this->setUpSparql();
+    $base_url = $_ENV['SIMPLETEST_BASE_URL'];
+    $this->import($base_url, $this->sparql, 'phpunit');
+    $this->enableGraph('fruit');
+    $this->enableGraph('vegetables');
+
+    $this->drupalCreateContentType([
+      'type' => 'article',
+    ]);
+
+    $this->drupalLogin($this->drupalCreateUser([], $this->randomString(), TRUE));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tearDown() {
+    $base_url = $_ENV['SIMPLETEST_BASE_URL'];
+    $this->clear($base_url, $this->sparql, 'phpunit');
+
+    parent::tearDown();
+  }
+
+  /**
+   * Tests the skos concept selection form.
+   */
+  public function testSelectionConfigForm(): void {
+    $this->drupalGet('admin/structure/types/manage/article/fields/add-field');
+    $this->getSession()->getPage()->selectFieldOption('Add a new field', 'skos_concept_entity_reference');
+    $this->getSession()->getPage()->fillField('Label', 'Reference field');
+    $this->assertSession()->waitForText('Machine name: reference_field');
+    $this->getSession()->getPage()->pressButton('Save and continue');
+    $this->getSession()->getPage()->pressButton('Save field settings');
+
+    // Assert we have the concept schemes selection element.
+    $this->assertSession()->selectExists('Concept Schemes');
+    $this->assertSession()->optionExists('Concept Schemes', 'http://example.com/fruit');
+    $this->assertSession()->optionExists('Concept Schemes', 'http://example.com/vegetables');
+
+    // With no concept schemes selected, we don't have any concept subset
+    // element.
+    $this->assertSession()->fieldNotExists('Concept subset');
+
+    // Select the Vegetable scheme and assert we show the right subset for
+    // selection.
+    $this->getSession()->getPage()->selectFieldOption('Concept Schemes', 'http://example.com/vegetables');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $this->assertSession()->selectExists('Concept subset');
+    $this->assertSession()->optionExists('Concept subset', 'any_alter');
+    $this->assertSession()->optionNotExists('Concept subset', 'fruit_alter');
+
+    // Select the Fruit scheme and assert that we show both subsets.
+    $this->getSession()->getPage()->selectFieldOption('Concept Schemes', 'http://example.com/fruit');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $this->assertSession()->selectExists('Concept subset');
+    $this->assertSession()->optionExists('Concept subset', 'any_alter');
+    $this->assertSession()->optionExists('Concept subset', 'fruit_alter');
+
+    $this->getSession()->getPage()->selectFieldOption('Concept subset', 'fruit_alter');
+
+    $this->getSession()->getPage()->pressButton('Save settings');
+    $this->assertSession()->pageTextContains('Saved Reference field configuration.');
+
+    // Edit back the form and assert the correct default values are set.
+    $link = $this->getSession()->getPage()->find('xpath', '//tr/td[normalize-space(text())="field_reference_field"]/..//a[normalize-space(text())="Edit"]');
+    $link->click();
+
+    $this->assertSession()->selectExists('Concept Schemes');
+    $option = $this->assertSession()->optionExists('Concept Schemes', 'http://example.com/fruit');
+    $this->assertTrue($option->hasAttribute('selected'));
+    $option = $this->assertSession()->optionExists('Concept Schemes', 'http://example.com/vegetables');
+    $this->assertFalse($option->hasAttribute('selected'));
+
+    $this->assertSession()->selectExists('Concept subset');
+    $option = $this->assertSession()->optionExists('Concept subset', 'any_alter');
+    $this->assertFalse($option->hasAttribute('selected'));
+    $option = $this->assertSession()->optionExists('Concept subset', 'fruit_alter');
+    $this->assertTrue($option->hasAttribute('selected'));
+  }
+
+}

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -221,22 +221,26 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
   public function testPluginsApplicability(): void {
     /** @var \Drupal\rdf_skos\ConceptSubsetPluginManagerInterface $manaer */
     $manager = $this->container->get('plugin.manager.concept_subset');
-    $definitions = $manager->getApplicableDefinitions(['http://example.com/fruit']);
+    $definitions = array_keys($manager->getApplicableDefinitions(['http://example.com/fruit']));
     $expected = [
-      'predicate_mapping',
       'any_alter',
-      'multi_alter',
       'fruit_alter',
-    ];
-    $this->assertEquals($expected, array_keys($definitions));
-
-    $definitions = $manager->getApplicableDefinitions(['http://example.com/fruit', 'http://example.com/vegetables']);
-    $expected = [
+      'multi_alter',
       'predicate_mapping',
+    ];
+
+    sort($definitions);
+    $this->assertEquals($expected, $definitions);
+
+    $definitions = array_keys($manager->getApplicableDefinitions(['http://example.com/fruit', 'http://example.com/vegetables']));
+    $expected = [
       'any_alter',
       'multi_alter',
+      'predicate_mapping',
     ];
-    $this->assertEquals($expected, array_keys($definitions));
+
+    sort($definitions);
+    $this->assertEquals($expected, $definitions);
   }
 
   /**

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -221,7 +221,7 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
   public function testPluginsApplicability(): void {
     /** @var \Drupal\rdf_skos\ConceptSubsetPluginManagerInterface $manaer */
     $manager = $this->container->get('plugin.manager.concept_subset');
-    $definitions = $manager->getApplicableDefinitionsDefinitions(['http://example.com/fruit']);
+    $definitions = $manager->getApplicableDefinitions(['http://example.com/fruit']);
     $expected = [
       'fruit_alter',
       'predicate_mapping',
@@ -230,7 +230,7 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
     ];
     $this->assertEquals($expected, array_keys($definitions));
 
-    $definitions = $manager->getApplicableDefinitionsDefinitions(['http://example.com/fruit', 'http://example.com/vegetables']);
+    $definitions = $manager->getApplicableDefinitions(['http://example.com/fruit', 'http://example.com/vegetables']);
     $expected = [
       'predicate_mapping',
       'any_alter',

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -223,10 +223,10 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
     $manager = $this->container->get('plugin.manager.concept_subset');
     $definitions = $manager->getApplicableDefinitions(['http://example.com/fruit']);
     $expected = [
-      'fruit_alter',
       'predicate_mapping',
       'any_alter',
       'multi_alter',
+      'fruit_alter',
     ];
     $this->assertEquals($expected, array_keys($definitions));
 

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -216,6 +216,30 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
   }
 
   /**
+   * Tests the applicable plugin definitions by concept schemes.
+   */
+  public function testPluginsApplicability(): void {
+    /** @var \Drupal\rdf_skos\ConceptSubsetPluginManagerInterface $manaer */
+    $manager = $this->container->get('plugin.manager.concept_subset');
+    $definitions = $manager->getApplicableDefinitionsDefinitions(['http://example.com/fruit']);
+    $expected = [
+      'fruit_alter',
+      'predicate_mapping',
+      'any_alter',
+      'multi_alter',
+    ];
+    $this->assertEquals($expected, array_keys($definitions));
+
+    $definitions = $manager->getApplicableDefinitionsDefinitions(['http://example.com/fruit', 'http://example.com/vegetables']);
+    $expected = [
+      'predicate_mapping',
+      'any_alter',
+      'multi_alter',
+    ];
+    $this->assertEquals($expected, array_keys($definitions));
+  }
+
+  /**
    * Tests that concept subsets can map new predicates to custom fields.
    */
   public function testConceptSubsetPredicateMapping(): void {

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -175,4 +175,62 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
     $this->assertCount(0, $violations);
   }
 
+  /**
+   * Tests that concept subsets can be used to alter the queries.
+   */
+  public function testConceptSubsetQueryAlter(): void {
+    // Create a reference field to Fruit, using the fruit_alter subset.
+    $this->createSkosConceptReferenceField(
+      'entity_test',
+      'entity_test',
+      ['http://example.com/fruit'],
+      'field_fruit',
+      'Fruit',
+      NULL,
+      'fruit_alter'
+    );
+
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+
+    /** @var \Drupal\entity_test\Entity\EntityTest $entity */
+    $entity = $entity_type_manager->getStorage('entity_test')
+      ->create(['type' => 'entity_test']);
+
+    // Since we are using the subset, only one single concept can be referenced.
+    $entity->set('field_fruit', 'http://example.com/fruit/citrus-fruit');
+    $violations = $entity->field_fruit->validate();
+    $this->assertCount(0, $violations);
+    $fruits = [
+      'http://example.com/fruit/apple',
+      'http://example.com/fruit/exotic-fruit',
+      'http://example.com/fruit/lemon',
+    ];
+
+    foreach ($fruits as $fruit) {
+      $entity->set('field_fruit', $fruit);
+      $violations = $entity->field_fruit->validate();
+      $this->assertCount(1, $violations);
+      $this->assertEquals(t('This entity (%type: %id) cannot be referenced.', ['%type' => 'skos_concept', '%id' => $fruit]), $violations[0]->getMessage());
+    }
+  }
+
+  /**
+   * Tests that concept subsets can map new predicates to custom fields.
+   */
+  public function testConceptSubsetPredicateMapping(): void {
+    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
+    $entity_field_manager = $this->container->get('entity_field.manager');
+    $fields = $entity_field_manager->getBaseFieldDefinitions('skos_concept');
+    $this->assertContains('dummy_title', array_keys($fields));
+    /** @var \Drupal\Core\Field\BaseFieldDefinition $field */
+    $field = $fields['dummy_title'];
+    $this->assertEquals('A dummy title', $field->getLabel());
+
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    $concept = $entity_type_manager->getStorage('skos_concept')->load('http://example.com/fruit/citrus-fruit');
+    $this->assertEquals('A dummy value that is not skos.', $concept->get('dummy_title')->value);
+  }
+
 }

--- a/tests/Traits/SkosEntityReferenceTrait.php
+++ b/tests/Traits/SkosEntityReferenceTrait.php
@@ -27,8 +27,10 @@ trait SkosEntityReferenceTrait {
    *   The field label.
    * @param string|null $widget
    *   The widget plugin ID if one is needed. NULL otherwise.
+   * @param string|null $concept_subset
+   *   An optional concept subset plugin.
    */
-  protected function createSkosConceptReferenceField(string $entity_type, string $bundle, array $concept_schemes, string $field_name, string $field_label, string $widget = NULL): void {
+  protected function createSkosConceptReferenceField(string $entity_type, string $bundle, array $concept_schemes, string $field_name, string $field_label, string $widget = NULL, string $concept_subset = NULL): void {
     $handler_settings = [
       'target_bundles' => NULL,
       'auto_create' => FALSE,
@@ -40,6 +42,10 @@ trait SkosEntityReferenceTrait {
         'concept_schemes' => $concept_schemes,
       ],
     ];
+
+    if ($concept_subset) {
+      $handler_settings['concept_subset'] = $concept_subset;
+    }
 
     if (!FieldStorageConfig::loadByName($entity_type, $field_name)) {
       FieldStorageConfig::create([

--- a/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/AnySchemeAlterSubset.php
+++ b/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/AnySchemeAlterSubset.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_test\Plugin\ConceptSubset;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\rdf_skos\ConceptSubsetPluginBase;
+
+/**
+ * Test plugin that can alter the query of any scheme.
+ *
+ * @ConceptSubset(
+ *   id = "any_alter",
+ *   label = @Translation("Any alter"),
+ *   description = @Translation("Alters any concept scheme queries.")
+ * )
+ */
+class AnySchemeAlterSubset extends ConceptSubsetPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterQuery(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void {
+    // We don't actually alter the query but use this plugin to test that it
+    // is always available.
+  }
+
+}

--- a/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/FruitSchemeAlterSubset.php
+++ b/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/FruitSchemeAlterSubset.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_test\Plugin\ConceptSubset;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\rdf_skos\ConceptSubsetPluginBase;
+
+/**
+ * Test plugin that only works with Fruit concepts.
+ *
+ * @ConceptSubset(
+ *   id = "fruit_alter",
+ *   label = @Translation("Fruit alter"),
+ *   description = @Translation("Alters the fruit concept queries."),
+ *   concept_schemes = {
+ *     "http://example.com/fruit"
+ *   },
+ * )
+ */
+class FruitSchemeAlterSubset extends ConceptSubsetPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterQuery(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void {
+    // Allow only one fruit in this subset.
+    $query->condition('id', 'http://example.com/fruit/citrus-fruit');
+  }
+
+}

--- a/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/MultiSchemeAlterSubset.php
+++ b/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/MultiSchemeAlterSubset.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_test\Plugin\ConceptSubset;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\rdf_skos\ConceptSubsetPluginBase;
+
+/**
+ * Test plugin that only works with Fruit and Vegetable concepts.
+ *
+ * @ConceptSubset(
+ *   id = "multi_alter",
+ *   label = @Translation("multi alter"),
+ *   description = @Translation("Alters the fruit and vegetables concept queries."),
+ *   concept_schemes = {
+ *     "http://example.com/fruit",
+ *     "http://example.com/vegetables",
+ *   },
+ * )
+ */
+class MultiSchemeAlterSubset extends ConceptSubsetPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterQuery(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void {
+    // Perform no alteration.
+  }
+
+}

--- a/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/PredicateMappingSubset.php
+++ b/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/PredicateMappingSubset.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_test\Plugin\ConceptSubset;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
+use Drupal\rdf_skos\ConceptSubsetPluginBase;
+use Drupal\rdf_skos\Plugin\PredicateMapperInterface;
+
+/**
+ * Test plugin that maps a new value to a new base field.
+ *
+ * @ConceptSubset(
+ *   id = "predicate_mapping",
+ *   label = @Translation("Predicate mapping"),
+ *   description = @Translation("Maps a new value to a new base field."),
+ *   predicate_mapping = "TRUE"
+ * )
+ */
+class PredicateMappingSubset extends ConceptSubsetPluginBase implements PredicateMapperInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterQuery(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void {
+    // We don't need to alter the query for this test.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPredicateMapping(): array {
+    $mapping = [];
+
+    $mapping['dummy_title'] = [
+      'column' => 'value',
+      'predicate' => ['http://www.w3.org/2004/02/skos/core#dummy'],
+      'format' => RdfFieldHandlerInterface::TRANSLATABLE_LITERAL,
+    ];
+
+    return $mapping;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseFieldDefinitions(): array {
+    $fields = [];
+
+    $fields['dummy_title'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('A dummy title'))
+      ->setDescription(t('A dummy title value.'));
+
+    return $fields;
+  }
+
+}

--- a/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/PredicateMappingSubset.php
+++ b/tests/modules/rdf_skos_test/src/Plugin/ConceptSubset/PredicateMappingSubset.php
@@ -17,7 +17,7 @@ use Drupal\rdf_skos\Plugin\PredicateMapperInterface;
  *   id = "predicate_mapping",
  *   label = @Translation("Predicate mapping"),
  *   description = @Translation("Maps a new value to a new base field."),
- *   predicate_mapping = "TRUE"
+ *   predicate_mapping = TRUE
  * )
  */
 class PredicateMappingSubset extends ConceptSubsetPluginBase implements PredicateMapperInterface {

--- a/tests/test_rdf/fruit.rdf
+++ b/tests/test_rdf/fruit.rdf
@@ -20,6 +20,7 @@
         <skos:hiddenLabel xml:lang="en">Citrus fruit HIDDEN</skos:hiddenLabel>
         <skos:example xml:lang="en">lemons, oranges, limes, mandarines, grapefruit, satsumas</skos:example>
         <skos:definition xml:lang="en">Fruit that make you salivate sometimes</skos:definition>
+        <skos:dummy xml:lang="en">A dummy value that is not skos.</skos:dummy>
     </skos:Concept>
     <skos:Concept rdf:about="http://example.com/fruit/exotic-fruit">
         <skos:inScheme rdf:resource="http://example.com/fruit"/>


### PR DESCRIPTION
This PR creates the `ConceptSubset` plugin type that allows the definition of a subset of concepts within which the SKOS Concept entity reference selection plugin can query.

Subsets are used to define adhoc groups of concepts within a scheme that can be configured and used in an en entity reference field that references SKOS Concepts.