### PR TITLE
EWPP-280: Allowing the mapping of multiple fields to 1 predicate.

### DIFF
--- a/src/RdfSkosFieldHandler.php
+++ b/src/RdfSkosFieldHandler.php
@@ -82,7 +82,7 @@ class RdfSkosFieldHandler extends RdfFieldHandler {
             'data_type' => $data_type,
           ];
 
-          $this->inboundMap[$entity_type_id]['fields'][$predicate][$entity_type_id] = [
+          $this->inboundMap[$entity_type_id]['fields'][$predicate][$entity_type_id][] = [
             'field_name' => $field_name,
             'column' => $field_mapping['column'],
             'serialize' => FALSE,
@@ -99,7 +99,7 @@ class RdfSkosFieldHandler extends RdfFieldHandler {
           'data_type' => $data_type,
         ];
 
-        $this->inboundMap[$entity_type_id]['fields'][$field_mapping['predicate']][$entity_type_id] = [
+        $this->inboundMap[$entity_type_id]['fields'][$field_mapping['predicate']][$entity_type_id][] = [
           'field_name' => $field_name,
           'column' => $field_mapping['column'],
           'serialize' => FALSE,

--- a/tests/Kernel/RdfSkosEntityReferenceTest.php
+++ b/tests/Kernel/RdfSkosEntityReferenceTest.php
@@ -266,4 +266,19 @@ class RdfSkosEntityReferenceTest extends RdfSkosKernelTestBase {
     $this->assertEquals('A dummy value that is not skos.', $concept->get('dummy_title')->value);
   }
 
+  /**
+   * Tests that we can map multiple fields to a single predicate.
+   */
+  public function testMultipleFieldMappings(): void {
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    /** @var \Drupal\rdf_skos\Entity\ConceptInterface $concept */
+    $concept = $entity_type_manager->getStorage('skos_concept')->load('http://example.com/fruit/citrus-fruit');
+    foreach (['dummy_field_one', 'dummy_field_two'] as $name) {
+      $this->assertTrue($concept->hasField($name));
+    }
+    $this->assertEquals('A dummy value that is not skos.', $concept->get('dummy_field_one')->value);
+    $this->assertEquals('A dummy value that is not skos.', $concept->get('dummy_field_two')->value);
+  }
+
 }

--- a/tests/modules/rdf_skos_test/rdf_skos_test.module
+++ b/tests/modules/rdf_skos_test/rdf_skos_test.module
@@ -8,6 +8,8 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Database\Query\AlterableInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
  * Implements hook_query_QUERY_TAG_alter().
@@ -24,4 +26,28 @@ function rdf_skos_test_query_skos_concept_field_selection_plugin_alter(Alterable
   if ($field_info['field_name'] === 'field_fruit' && count($field_info['concept_schemes']) === 1 && $field_info['concept_schemes'][0] === 'http://example.com/fruit' && $condition) {
     $query->condition($condition['field'], $condition['value']);
   }
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ *
+ * Define two dummy base fields on the Concept entity in order to test we can
+ * map a single predicate to both of them.
+ */
+function rdf_skos_test_entity_base_field_info(EntityTypeInterface $entity_type) {
+  if ($entity_type->id() !== 'skos_concept') {
+    return [];
+  }
+
+  $fields = [];
+
+  $fields['dummy_field_one'] = BaseFieldDefinition::create('string')
+    ->setLabel(t('A dummy title for field one'))
+    ->setDescription(t('A dummy title value for field one.'));
+
+  $fields['dummy_field_two'] = BaseFieldDefinition::create('string')
+    ->setLabel(t('A dummy title for field two'))
+    ->setDescription(t('A dummy title value for field two.'));
+
+  return $fields;
 }

--- a/tests/modules/rdf_skos_test/rdf_skos_test.services.yml
+++ b/tests/modules/rdf_skos_test/rdf_skos_test.services.yml
@@ -3,3 +3,7 @@ services:
     class: Drupal\rdf_skos_test\EventSubscriber\TestSkosActiveGraphSubscriber
     tags:
       - { name: event_subscriber }
+  rdf_skos_test.predicate_mapping_subscriber:
+    class: Drupal\rdf_skos_test\EventSubscriber\SkosPredicateMappingTestSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/tests/modules/rdf_skos_test/src/EventSubscriber/SkosPredicateMappingTestSubscriber.php
+++ b/tests/modules/rdf_skos_test/src/EventSubscriber/SkosPredicateMappingTestSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_test\EventSubscriber;
+
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
+use Drupal\rdf_skos\Event\SkosPredicateMappingEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribes to the SKOS predicate mapping event.
+ *
+ * The purpose is to map a single predicate to two separately defined base
+ * fields and ensure that it works.
+ */
+class SkosPredicateMappingTestSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[SkosPredicateMappingEvent::EVENT][] = ['onPredicateMapping', 20];
+    return $events;
+  }
+
+  /**
+   * Maps a predicate to a custom base field on the Skos Concept.
+   *
+   * @param \Drupal\rdf_skos\Event\SkosPredicateMappingEvent $event
+   *   The event.
+   *
+   * @see \oe_content_organisation_entity_base_field_info()
+   */
+  public function onPredicateMapping(SkosPredicateMappingEvent $event): void {
+    $mapping = $event->getMapping();
+    $entity_type_id = $event->getEntityTypeId();
+
+    if ($entity_type_id === 'skos_concept') {
+      $mapping['fields']['dummy_field_one'] = [
+        'column' => 'value',
+        'predicate' => ['http://www.w3.org/2004/02/skos/core#dummy'],
+        'format' => RdfFieldHandlerInterface::TRANSLATABLE_LITERAL,
+      ];
+
+      $mapping['fields']['dummy_field_two'] = [
+        'column' => 'value',
+        'predicate' => ['http://www.w3.org/2004/02/skos/core#dummy'],
+        'format' => RdfFieldHandlerInterface::TRANSLATABLE_LITERAL,
+      ];
+    }
+
+    $event->setMapping($mapping);
+  }
+
+}


### PR DESCRIPTION
The first commit proves the problem, the second fixes it.

The issue is caused by the fact that the `RdfSkosFieldHandler::buildEntityTypeProperties()` prepares the inbound map (which is the map of predicates to fields used when hydrating the entities from the triple store) in a way in which it allows only one predicate per field (the array is keyed by predicate) so if there are more fields, only one will go through. See also the parent.

The `RdfEntitySparqlStorage::processGraphResults()` then uses this map to hydrate the triple values. Unfortunately, in doing so, it assumes that the inbound map only contains one predicate->field mapping. 

So in this PR:

* I transformed the inbound map to contain an array of field mappings per predicate
* Completely overrode the `processGraphResults()` inside `SkosEntityStorage` in order to account for the change in the inbound map. Much of it is copied from the parent, apart from this change.