### PR TITLE
EWPP-564: Skos entity definition update manager.

### DIFF
--- a/rdf_skos.services.yml
+++ b/rdf_skos.services.yml
@@ -22,3 +22,6 @@ services:
   plugin.manager.concept_subset:
     class: Drupal\rdf_skos\ConceptSubsetPluginManager
     parent: default_plugin_manager
+  rdf_skos.skos_entity_definition_update_manager:
+    class: Drupal\rdf_skos\SkosEntityDefinitionUpdateManager
+    arguments: ['@entity.definition_update_manager', '@entity_field.manager']

--- a/src/SkosEntityDefinitionUpdateManager.php
+++ b/src/SkosEntityDefinitionUpdateManager.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos;
+
+use Drupal\Core\Entity\EntityDefinitionUpdateManager;
+use Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+
+/**
+ * Updates the definitions of the defined Skos concept fields.
+ *
+ * New Skos concept fields can be defined as part of ConceptSubset plugins so
+ * whenever we have a new field, we need to use this service to update their
+ * definition.
+ */
+class SkosEntityDefinitionUpdateManager {
+
+  /**
+   * The core entity definition update manager.
+   *
+   * @var \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface
+   */
+  protected $entityDefinitionUpdateManager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * SkosConceptEntityDefinitionUpdateManager constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface $entityDefinitionUpdateManager
+   *   The core entity definition update manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager
+   *   The entity field manager.
+   */
+  public function __construct(EntityDefinitionUpdateManagerInterface $entityDefinitionUpdateManager, EntityFieldManagerInterface $entityFieldManager) {
+    $this->entityDefinitionUpdateManager = $entityDefinitionUpdateManager;
+    $this->entityFieldManager = $entityFieldManager;
+  }
+
+  /**
+   * Installs all the field definitions.
+   *
+   * @param string $entity_type
+   *   The entity type.
+   *
+   * @return array
+   *   The installed field names.
+   */
+  public function installFieldDefinitions(string $entity_type = 'skos_concept'): array {
+    $installed = [];
+
+    $change_list = $this->entityDefinitionUpdateManager->getChangeList();
+    $changed_definitions = $change_list[$entity_type]['field_storage_definitions'] ?? [];
+    if (!$changed_definitions) {
+      return $installed;
+    }
+
+    $field_names = [];
+    foreach ($changed_definitions as $field_name => $status) {
+      if ($status === EntityDefinitionUpdateManager::DEFINITION_CREATED) {
+        $field_names[] = $field_name;
+      }
+    }
+
+    $all_definitions = $this->entityFieldManager->getFieldStorageDefinitions($entity_type);
+    $definitions = [];
+    foreach ($all_definitions as $name => $definition) {
+      if (in_array($name, $field_names)) {
+        $definitions[$name] = $definition;
+      }
+    }
+
+    foreach ($definitions as $name => $definition) {
+      $this->entityDefinitionUpdateManager->installFieldStorageDefinition($name, $entity_type, $definition->getProvider(), $definition);
+      $installed[] = $name;
+    }
+
+    return $installed;
+  }
+
+}

--- a/src/SkosEntityDefinitionUpdateManager.php
+++ b/src/SkosEntityDefinitionUpdateManager.php
@@ -49,19 +49,21 @@ class SkosEntityDefinitionUpdateManager {
    *
    * @param string $entity_type
    *   The entity type.
+   * @param array $definitions
+   *   The definitions to install.
    *
    * @return array
    *   The installed field names.
    */
-  public function installFieldDefinitions(string $entity_type = 'skos_concept'): array {
-    $installed = [];
-
+  public function installFieldDefinitions(string $entity_type = 'skos_concept', array $definitions = []): array {
     $change_list = $this->entityDefinitionUpdateManager->getChangeList();
     $changed_definitions = $change_list[$entity_type]['field_storage_definitions'] ?? [];
     if (!$changed_definitions) {
-      return $installed;
+      // If there are no fields to install, we bail out.
+      return [];
     }
 
+    // Get a list of all the field names that need to be installed.
     $field_names = [];
     foreach ($changed_definitions as $field_name => $status) {
       if ($status === EntityDefinitionUpdateManager::DEFINITION_CREATED) {
@@ -69,14 +71,40 @@ class SkosEntityDefinitionUpdateManager {
       }
     }
 
+    if ($definitions) {
+      // In case too many definitions were passed, filter out the ones that
+      // don't need to be installed.
+      $definitions = array_filter($definitions, function ($definition, $field_name) use ($field_names) {
+        return in_array($field_name, $field_names);
+      }, ARRAY_FILTER_USE_BOTH);
+
+      return $this->doInstallDefinitions($entity_type, $definitions);
+    }
+
+    // If no definitions were passed, we use the current ones.
     $all_definitions = $this->entityFieldManager->getFieldStorageDefinitions($entity_type);
-    $definitions = [];
     foreach ($all_definitions as $name => $definition) {
       if (in_array($name, $field_names)) {
         $definitions[$name] = $definition;
       }
     }
 
+    return $this->doInstallDefinitions($entity_type, $definitions);
+  }
+
+  /**
+   * Installs a number of field definitions.
+   *
+   * @param string $entity_type
+   *   The entity type.
+   * @param array $definitions
+   *   The array of definitions, keyed by field name.
+   *
+   * @return array
+   *   The installed definitions.
+   */
+  protected function doInstallDefinitions(string $entity_type, array $definitions): array {
+    $installed = [];
     foreach ($definitions as $name => $definition) {
       $this->entityDefinitionUpdateManager->installFieldStorageDefinition($name, $entity_type, $definition->getProvider(), $definition);
       $installed[] = $name;

--- a/tests/Kernel/RdfSkosKernelTestBase.php
+++ b/tests/Kernel/RdfSkosKernelTestBase.php
@@ -28,6 +28,9 @@ class RdfSkosKernelTestBase extends RdfKernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    $this->installEntitySchema('skos_concept');
+    $this->installEntitySchema('skos_concept_scheme');
+
     $base_url = $_ENV['SIMPLETEST_BASE_URL'];
     $this->import($base_url, $this->sparql, 'phpunit');
   }

--- a/tests/modules/rdf_skos_entity_definition_test/rdf_skos_entity_definition_test.info.yml
+++ b/tests/modules/rdf_skos_entity_definition_test/rdf_skos_entity_definition_test.info.yml
@@ -1,0 +1,8 @@
+name: 'RDF SKOS entity definition test module'
+type: module
+description: 'Tests the entity definition update manager.'
+package: Testing
+version: VERSION
+core: 8.x
+dependencies:
+  - rdf_skos:rdf_skos

--- a/tests/modules/rdf_skos_entity_definition_test/src/Plugin/ConceptSubset/NewPredicateMappingSubset.php
+++ b/tests/modules/rdf_skos_entity_definition_test/src/Plugin/ConceptSubset/NewPredicateMappingSubset.php
@@ -35,7 +35,13 @@ class NewPredicateMappingSubset extends ConceptSubsetPluginBase implements Predi
   public function getPredicateMapping(): array {
     $mapping = [];
 
-    $mapping['new_dummy_title'] = [
+    $mapping['first_new_dummy_title'] = [
+      'column' => 'value',
+      'predicate' => ['http://www.w3.org/2004/02/skos/core#dummy'],
+      'format' => RdfFieldHandlerInterface::TRANSLATABLE_LITERAL,
+    ];
+
+    $mapping['second_new_dummy_title'] = [
       'column' => 'value',
       'predicate' => ['http://www.w3.org/2004/02/skos/core#dummy'],
       'format' => RdfFieldHandlerInterface::TRANSLATABLE_LITERAL,
@@ -50,9 +56,13 @@ class NewPredicateMappingSubset extends ConceptSubsetPluginBase implements Predi
   public function getBaseFieldDefinitions(): array {
     $fields = [];
 
-    $fields['new_dummy_title'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('A new dummy title'))
-      ->setDescription(t('A dummy title added to the definition after installation of RDF Skos.'));
+    $fields['first_new_dummy_title'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('A first new dummy title'))
+      ->setDescription(t('A first dummy title added to the definition after installation of RDF Skos.'));
+
+    $fields['second_new_dummy_title'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('A second new dummy title'))
+      ->setDescription(t('A second dummy title added to the definition after installation of RDF Skos.'));
 
     return $fields;
   }

--- a/tests/modules/rdf_skos_entity_definition_test/src/Plugin/ConceptSubset/NewPredicateMappingSubset.php
+++ b/tests/modules/rdf_skos_entity_definition_test/src/Plugin/ConceptSubset/NewPredicateMappingSubset.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\rdf_skos_entity_definition_test\Plugin\ConceptSubset;
+
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\rdf_entity\RdfFieldHandlerInterface;
+use Drupal\rdf_skos\ConceptSubsetPluginBase;
+use Drupal\rdf_skos\Plugin\PredicateMapperInterface;
+
+/**
+ * Test plugin that maps a new value to a new base field.
+ *
+ * @ConceptSubset(
+ *   id = "new_predicate_mapping",
+ *   label = @Translation("New predicate mapping"),
+ *   description = @Translation("Maps a new value to a new base field."),
+ *   predicate_mapping = TRUE
+ * )
+ */
+class NewPredicateMappingSubset extends ConceptSubsetPluginBase implements PredicateMapperInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterQuery(QueryInterface $query, $match_operator, array $concept_schemes = [], string $match = NULL): void {
+    // We don't need to alter the query for this test.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPredicateMapping(): array {
+    $mapping = [];
+
+    $mapping['new_dummy_title'] = [
+      'column' => 'value',
+      'predicate' => ['http://www.w3.org/2004/02/skos/core#dummy'],
+      'format' => RdfFieldHandlerInterface::TRANSLATABLE_LITERAL,
+    ];
+
+    return $mapping;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseFieldDefinitions(): array {
+    $fields = [];
+
+    $fields['new_dummy_title'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('A new dummy title'))
+      ->setDescription(t('A dummy title added to the definition after installation of RDF Skos.'));
+
+    return $fields;
+  }
+
+}


### PR DESCRIPTION
Provides a service that can be used whenever a new base field is defined on the RDF Skos entity type (such as for concept subsets) in order to bring the field definitions in line with the installed versions.